### PR TITLE
Fix Docker inspect example: replace deprecated ContainerConfig with Config

### DIFF
--- a/cmd-or-entrypoint/step1/text.md
+++ b/cmd-or-entrypoint/step1/text.md
@@ -57,7 +57,7 @@ Explore CMD of `cmd-echo`:
 <br>
 
 ```plain
-docker inspect cmd-echo | jq .[0].ContainerConfig.Cmd
+docker inspect cmd-echo | jq .[0].Config.Cmd
 ```{{exec}}
 
 <br>


### PR DESCRIPTION
### What changed
Replaced `.ContainerConfig.Cmd` with `.Config.Cmd` in the docker inspect example.

### Why
Modern Docker versions (20+) no longer expose `ContainerConfig` consistently.
The existing command fails or returns null in current environments, breaking
learner labs.

### Result
The updated command works reliably across:
- Docker 20+
- OCI-compliant images
- KillerKoda interactive labs